### PR TITLE
Make connector work with server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tdvt_workspace
 *.bbprojectd
 .venv
+.idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Developing DuckDB Tableau Connector
+
+## Notes on manifest.xml
+### <connector-plugin> tag
+* `plugin-version` attribute is the version seen by users in Tableau Exchange. 
+Increment it whenever the connector changes.
+* `version` attribute refers to an internal Tableau version and should not be changed.
+
+### <connection-customization>
+* `version` attribute is not used by Tableau.
+Leave it at 1.0 unless connection-customization changes.
+
+## Releasing
+
+# Update user-agent connector version
+In `connectionProperties.js`, please update `MOTHERDUCK_CONNECTOR_VERSION` to the latest version.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Adding new drivers to Tableau is a bit tricky, but hopefully these directions sh
 
 ### JDBC Driver
 
-The connector uses the 0.8.2+ DuckDB JDBC driver. 
+The connector works with DuckDB JDBC driver v0.9.2 or higher. 
 This is partly because the ODBC driver does not seem to work well on MacOS.
 
 At a high level, you need to download a recent version of the driver and 

--- a/tableau_connectors/duckdb_jdbc/connectionFields.xml
+++ b/tableau_connectors/duckdb_jdbc/connectionFields.xml
@@ -1,6 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <connection-fields>
-  <field name="authentication" label="Authentication" category="authentication" value-type="string" editable="false" default-value="auth-none" />
-  <field name="server" label="@string/database_prompt/" category="general" value-type="file" editable="true" default-value="" />
+  <field name="server" label="DuckDB Server" category="general" value-type="selection" editable="true" default-value="local" >
+    <selection-group>
+      <option value="local" label="Local File"/>
+      <option value="memory" label="In-memory database"/>
+      <option value="motherduck" label="MotherDuck"/>
+      <option value="custom" label="Custom connection string"/>
+    </selection-group>
+  </field>
+
+  <field name="authentication" label="Authentication" category="authentication" value-type="selection" editable="true" default-value="auth-none" >
+    <selection-group>
+      <conditions>
+        <condition field="server" value="motherduck"/>
+        <condition field="server" value="custom"/>
+      </conditions>
+      <option value="auth-none" label="No Authentication"/>
+      <option value="auth-pass" label="Token"/>
+    </selection-group>
+    <selection-group>
+      <conditions>
+        <condition field="server" value="local"/>
+        <condition field="server" value="memory"/>
+      </conditions>
+      <option value="auth-none" label="No Authentication"/>
+    </selection-group>
+  </field>
+  <field name="password" label="Token" category="authentication" value-type="string" secure="true">
+    <conditions>
+      <condition field="authentication" value="auth-pass"/>
+    </conditions>
+  </field>
+  <!-- Specifying the database location, depending on server: local file gets file selector, motherduck gets database name -->
+  <field name="v-connection_string_file" label="@string/database_prompt/" category="general" value-type="file" editable="true" default-value="" >
+    <conditions>
+      <condition field="server" value="local"/>
+    </conditions>
+  </field>
+  <field name="v-connection_string_md" label="MotherDuck Database" category="general" value-type="string" editable="true" default-value="" >
+    <conditions>
+      <condition field="server" value="motherduck"/>
+    </conditions>
+  </field>
+  <field name="v-connection_string_custom" label="Connection String" category="general" value-type="string" editable="true" default-value=":memory:" >
+    <conditions>
+      <condition field="server" value="custom"/>
+    </conditions>
+  </field>
 </connection-fields>

--- a/tableau_connectors/duckdb_jdbc/connectionProperties.js
+++ b/tableau_connectors/duckdb_jdbc/connectionProperties.js
@@ -1,7 +1,15 @@
 (function propertiesbuilder(attr) {
+    const MOTHERDUCK_CONNECTOR_VERSION = '1.0';
+
     // These are the DBClientConfig properties
     var props = {};
-    props['duckdb.read_only'] = (attr[connectionHelper.attributeServer] != ':memory:');
-    
+    props['duckdb.read_only'] = (attr[connectionHelper.attributeServer] !== 'memory');
+    props['custom_user_agent'] = 'tableau/' + MOTHERDUCK_CONNECTOR_VERSION + '('
+        + connectionHelper.GetProductName()
+        + '/' + connectionHelper.GetProductVersion()
+        + ' ' + connectionHelper.GetPlatform() + ')';
+    if (attr[connectionHelper.attributePassword]) {
+         props['motherduck_token'] = attr[connectionHelper.attributePassword];
+     }
     return props;
 })

--- a/tableau_connectors/duckdb_jdbc/connectionResolver.tdr
+++ b/tableau_connectors/duckdb_jdbc/connectionResolver.tdr
@@ -9,6 +9,11 @@
           <attribute-list>
             <attr>authentication</attr>
             <attr>server</attr>
+            <attr>password</attr>
+            <attr>initialSQL</attr>
+            <attr>v-connection_string_custom</attr>
+            <attr>v-connection_string_md</attr>
+            <attr>v-connection_string_local</attr>
           </attribute-list>
         </required-attributes>
       </connection-normalizer>

--- a/tableau_connectors/duckdb_jdbc/manifest.xml
+++ b/tableau_connectors/duckdb_jdbc/manifest.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='duckdb_jdbc' superclass='jdbc' plugin-version='0.8.1' name='DuckDB JDBC' version='0.8.1' min-version-tableau='2020.4'>
+<connector-plugin class='duckdb_jdbc' superclass='jdbc' plugin-version='1.0.0' name='DuckDB' version='18.1' min-version-tableau='2020.4'>
   <vendor-information>
       <company name="MotherDuck"/>
       <support-link url="https://github.com/MotherDuck-Open-Source/duckdb-tableau-connector"/>
-      <driver-download-link url="https://github.com/duckdb/duckdb/releases/tag/v0.8.1"/>
+      <driver-download-link url="https://github.com/duckdb/duckdb/releases"/>
   </vendor-information>
-  <connection-customization class="duckdb_jdbc" enabled="true" version="0.8.1">
+  <connection-customization class="duckdb_jdbc" enabled="true" version="1.0">
     <vendor name="vendor"/>
     <driver name="driver"/>
     <customizations>


### PR DESCRIPTION
Tableau server does not allow "file" widget. I've split up the single "server" field into several other options, so it's clear what to choose / fill out depending on the usecase.

There are 4 server modes:
- Local File (that's the familiar original option -- a file widget allows the file to be browsed for)
- In-memory database (users no longer have to type `:memory:`)
- MotherDuck (users provide a database name, although `md:database_name` is also accepted)
- Custom connection string (in case the other options don't work for some reason -- like when a local file is needed on the server side!)

When authenticating with MotherDuck or Custom, users can either choose "No authentication" or "Token". For local file / in-memory database, the authentication option is greyed out.

![image](https://github.com/MotherDuck-Open-Source/duckdb-tableau-connector/assets/41136058/00a0026a-fdad-470f-9b18-408c2984a49e)

![image](https://github.com/hawkfish/duckdb-taco/assets/41136058/f507c764-ef87-46e1-b50b-dac05ec9e872)
